### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/dev.aa55.yetty.yml
+++ b/dev.aa55.yetty.yml
@@ -10,6 +10,11 @@ finish-args:
   - --socket=pulseaudio
   - --device=all
   - --system-talk-name=org.freedesktop.login1
+cleanup:
+  - /include
+  - /lib/cmake
+  - '*.la'
+  - '*.a'
 modules:
   - name: libbacktrace
     buildsystem: autotools
@@ -20,6 +25,7 @@ modules:
       - type: git
         url: https://github.com/ianlancetaylor/libbacktrace.git
         commit: 793921876c981ce49759114d7bb89bb89b2d3a2d
+
   - name: boost
     buildsystem: simple
     build-commands:
@@ -29,6 +35,7 @@ modules:
       - type: archive
         url: https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2
         sha256: 46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b
+
   - name: yetty
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Add a basic cleanup command to remove development-related files, reducing the Flatpak size.

The installed size reduced from 149.7 MiB to 630.3 kB.