### PR TITLE
Fix missing icon error

### DIFF
--- a/dev.aa55.yetty.yml
+++ b/dev.aa55.yetty.yml
@@ -33,6 +33,8 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    post-install:
+      - gunzip -S z /app/share/icons/hicolor/scalable/apps/dev.aa55.yetty.svgz
     sources:
       - type: git
         url: https://github.com/aa55-dev/yeTTY.git


### PR DESCRIPTION
Convert the unsupported SVGZ format to svg to fix the missing icon error.

**Before**

<img width="195" height="167" alt="resim" src="https://github.com/user-attachments/assets/a17d4d49-a49c-4a3e-b646-4845650bdd13" />

**After**

<img width="195" height="167" alt="resim" src="https://github.com/user-attachments/assets/245fc667-5acf-4664-a28a-ba911705aff2" />
